### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,136 +1,136 @@
 version: 2
 updates:
   # Enable version updates for npm/pnpm
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
-      time: "08:00"
-      timezone: "Europe/Berlin"
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     reviewers:
-      - "@me"
+      - '@me'
     assignees:
-      - "@me"
+      - '@me'
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'
     labels:
-      - "dependencies"
-      - "automated"
+      - 'dependencies'
+      - 'automated'
     ignore:
       # Ignore major version updates for now (you can remove this if you want them)
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # Enable version updates for npm/pnpm in backend app
-  - package-ecosystem: "npm"
-    directory: "/apps/backend"
+  - package-ecosystem: 'npm'
+    directory: '/apps/backend'
     schedule:
-      interval: "daily"
-      time: "08:00"
-      timezone: "Europe/Berlin"
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     reviewers:
-      - "@me"
+      - '@me'
     assignees:
-      - "@me"
+      - '@me'
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'
     labels:
-      - "dependencies"
-      - "automated"
-      - "backend"
+      - 'dependencies'
+      - 'automated'
+      - 'backend'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # Enable version updates for npm/pnpm in frontend app
-  - package-ecosystem: "npm"
-    directory: "/apps/frontend"
+  - package-ecosystem: 'npm'
+    directory: '/apps/frontend'
     schedule:
-      interval: "daily"
-      time: "08:00"
-      timezone: "Europe/Berlin"
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     reviewers:
-      - "@me"
+      - '@me'
     assignees:
-      - "@me"
+      - '@me'
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'
     labels:
-      - "dependencies"
-      - "automated"
-      - "frontend"
+      - 'dependencies'
+      - 'automated'
+      - 'frontend'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # Enable version updates for npm/pnpm in worker app
-  - package-ecosystem: "npm"
-    directory: "/apps/worker"
+  - package-ecosystem: 'npm'
+    directory: '/apps/worker'
     schedule:
-      interval: "daily"
-      time: "08:00"
-      timezone: "Europe/Berlin"
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     reviewers:
-      - "@me"
+      - '@me'
     assignees:
-      - "@me"
+      - '@me'
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'
     labels:
-      - "dependencies"
-      - "automated"
-      - "worker"
+      - 'dependencies'
+      - 'automated'
+      - 'worker'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # Enable version updates for npm/pnpm in shared package
-  - package-ecosystem: "npm"
-    directory: "/packages/shared"
+  - package-ecosystem: 'npm'
+    directory: '/packages/shared'
     schedule:
-      interval: "daily"
-      time: "08:00"
-      timezone: "Europe/Berlin"
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     reviewers:
-      - "@me"
+      - '@me'
     assignees:
-      - "@me"
+      - '@me'
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: 'chore'
+      include: 'scope'
     labels:
-      - "dependencies"
-      - "automated"
-      - "shared"
+      - 'dependencies'
+      - 'automated'
+      - 'shared'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
-      time: "08:00"
-      timezone: "Europe/Berlin"
+      interval: 'daily'
+      time: '08:00'
+      timezone: 'Europe/Berlin'
     open-pull-requests-limit: 5
     reviewers:
-      - "@me"
+      - '@me'
     assignees:
-      - "@me"
+      - '@me'
     commit-message:
-      prefix: "ci"
-      include: "scope"
+      prefix: 'ci'
+      include: 'scope'
     labels:
-      - "dependencies"
-      - "automated"
-      - "github-actions"
+      - 'dependencies'
+      - 'automated'
+      - 'github-actions'


### PR DESCRIPTION
Create a new .github/dependabot.yml file to enable daily updates for npm/pnpm dependencies across various application directories (backend, frontend, worker, shared) and GitHub Actions. Configure limits on open pull requests and set up labels for better organization. Major version updates are currently ignored to maintain stability.